### PR TITLE
Refine action button design system showcase

### DIFF
--- a/lib/Components/Buttons/action_button.dart
+++ b/lib/Components/Buttons/action_button.dart
@@ -29,37 +29,104 @@ class ActionButton extends StatelessWidget {
     );
   }
 
+  bool get _isDisabled =>
+      !viewModel.enabled || viewModel.style == ActionButtonStyle.disabled;
+
   // Helper para obter a cor de fundo com base no estilo
   Color _getBackgroundColor() {
+    if (viewModel.backgroundColor != null) {
+      return viewModel.backgroundColor!;
+    }
+
+    if (_isDisabled) {
+      return viewModel.style == ActionButtonStyle.empty
+          ? Colors.transparent
+          : disabledColor;
+    }
+
     switch (viewModel.style) {
       case ActionButtonStyle.primary:
         return primaryColor;
       case ActionButtonStyle.secondary:
-        return secondaryColor;
+        return neutralLightGray;
       case ActionButtonStyle.destructive:
         return destructiveColor;
       case ActionButtonStyle.disabled:
         return disabledColor;
       case ActionButtonStyle.empty:
-        return emptyColor;
+        return Colors.transparent;
     }
   }
 
-  // Helper para obter a cor do texto/ícone
+  // Helper para obter a cor do texto
   Color _getForegroundColor() {
-    if (viewModel.style == ActionButtonStyle.disabled) {
-        return textMain;
+    if (viewModel.textColor != null) {
+      return viewModel.textColor!;
     }
 
-    if (viewModel.style == ActionButtonStyle.empty) {
-        return textMain;
+    if (_isDisabled) {
+      if (viewModel.style == ActionButtonStyle.empty) {
+        return textDisabled;
+      }
+
+      return Colors.white;
     }
 
-    return Colors.white;
+    switch (viewModel.style) {
+      case ActionButtonStyle.primary:
+        return textMain;
+      case ActionButtonStyle.secondary:
+        return textMain;
+      case ActionButtonStyle.destructive:
+        return Colors.white;
+      case ActionButtonStyle.empty:
+        return textMain;
+      case ActionButtonStyle.disabled:
+        return textMain;
+    }
+  }
+
+  Color _getIconColor() {
+    if (viewModel.iconColor != null) {
+      return viewModel.iconColor!;
+    }
+
+    if (_isDisabled) {
+      if (viewModel.style == ActionButtonStyle.empty) {
+        return textDisabled;
+      }
+
+      return Colors.white;
+    }
+
+    switch (viewModel.style) {
+      case ActionButtonStyle.destructive:
+        return Colors.white;
+      default:
+        return _getForegroundColor();
+    }
+  }
+
+  BorderSide? _getBorder() {
+    Color? color = viewModel.borderColor;
+
+    if (color == null) {
+      if (viewModel.style == ActionButtonStyle.empty) {
+        color = _isDisabled ? lightOutline : lightOutline;
+      }
+    }
+
+    if (color == null) {
+      return null;
+    }
+
+    return BorderSide(
+      color: _isDisabled ? color.withOpacity(0.6) : color,
+      width: 1.5,
+    );
   }
 
   // Helper para obter o tamanho do ícone com base no tamanho do botão
-  // Tamanho do ícone conforme tipo
   double _getIconSize() {
     switch (viewModel.size) {
       case ActionButtonSize.iconOnlySmall:
@@ -76,8 +143,7 @@ class ActionButton extends StatelessWidget {
         return 24.0;
     }
   }
-  
-  // Helper para obter o padding com base no tamanho do botão
+
   EdgeInsetsGeometry _getPadding() {
     switch (viewModel.size) {
       case ActionButtonSize.iconOnlySmall:
@@ -89,9 +155,54 @@ class ActionButton extends StatelessWidget {
       case ActionButtonSize.small:
         return const EdgeInsets.symmetric(vertical: 8, horizontal: 16);
       case ActionButtonSize.medium:
-        return const EdgeInsets.symmetric(vertical: 12, horizontal: 24);
+        return const EdgeInsets.symmetric(vertical: 12, horizontal: 20);
       case ActionButtonSize.large:
-        return const EdgeInsets.symmetric(vertical: 16, horizontal: 32);
+        return const EdgeInsets.symmetric(vertical: 16, horizontal: 24);
+    }
+  }
+
+  Size? _getFixedSize() {
+    switch (viewModel.size) {
+      case ActionButtonSize.iconOnlySmall:
+        return const Size.square(40);
+      case ActionButtonSize.iconOnlyMedium:
+        return const Size.square(48);
+      case ActionButtonSize.iconOnlyLarge:
+        return const Size.square(56);
+      default:
+        return null;
+    }
+  }
+
+  Size _getMinimumSize() {
+    switch (viewModel.size) {
+      case ActionButtonSize.small:
+        return const Size(64, 40);
+      case ActionButtonSize.medium:
+        return const Size(72, 48);
+      case ActionButtonSize.large:
+        return const Size(80, 56);
+      case ActionButtonSize.iconOnlySmall:
+        return const Size.square(40);
+      case ActionButtonSize.iconOnlyMedium:
+        return const Size.square(48);
+      case ActionButtonSize.iconOnlyLarge:
+        return const Size.square(56);
+    }
+  }
+
+  TextStyle _getTextStyle() {
+    switch (viewModel.size) {
+      case ActionButtonSize.small:
+        return poppinsRegular12;
+      case ActionButtonSize.medium:
+        return poppinsRegular14;
+      case ActionButtonSize.large:
+        return poppinsRegular16;
+      case ActionButtonSize.iconOnlySmall:
+      case ActionButtonSize.iconOnlyMedium:
+      case ActionButtonSize.iconOnlyLarge:
+        return poppinsRegular14;
     }
   }
 
@@ -100,7 +211,13 @@ class ActionButton extends StatelessWidget {
     final List<Widget> children = [];
 
     if (viewModel.icon != null) {
-      children.add(Icon(viewModel.icon, size: _getIconSize()));
+      children.add(
+        Icon(
+          viewModel.icon,
+          size: _getIconSize(),
+          color: _getIconColor(),
+        ),
+      );
     }
 
     if (viewModel.icon != null && viewModel.text != null) {
@@ -108,21 +225,32 @@ class ActionButton extends StatelessWidget {
     }
 
     if (viewModel.text != null) {
-      children.add(Text(viewModel.text!));
+      children.add(
+        Text(
+          viewModel.text!,
+          style: _getTextStyle().copyWith(color: _getForegroundColor()),
+        ),
+      );
     }
-    
+
     return ElevatedButton(
-      onPressed: (viewModel.style == ActionButtonStyle.disabled || !viewModel.enabled)
-          ? null
-          : () => delegate?.onClick(viewModel),
+      onPressed: _isDisabled ? null : () => delegate?.onClick(viewModel),
       style: ElevatedButton.styleFrom(
+        elevation: 0,
+        shadowColor: Colors.transparent,
         backgroundColor: _getBackgroundColor(),
+        disabledBackgroundColor:
+            viewModel.style == ActionButtonStyle.empty ? Colors.transparent : disabledColor,
         foregroundColor: _getForegroundColor(),
-        textStyle: poppinsRegular14,
+        disabledForegroundColor: _getForegroundColor(),
+        textStyle: _getTextStyle().copyWith(color: _getForegroundColor()),
         shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(10),
+          borderRadius: BorderRadius.circular(12),
+          side: _getBorder() ?? BorderSide.none,
         ),
         padding: _getPadding(),
+        minimumSize: _getMinimumSize(),
+        fixedSize: _getFixedSize(),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,

--- a/lib/Components/Buttons/action_button_view_model.dart
+++ b/lib/Components/Buttons/action_button_view_model.dart
@@ -23,6 +23,7 @@ class ActionButtonViewModel {
   final String? text;
   final IconData? icon;
   final bool enabled;
+  final Color? backgroundColor;
   final Color? iconColor;
   final Color? textColor;
   final Color? borderColor;
@@ -33,8 +34,9 @@ class ActionButtonViewModel {
     this.text,
     this.icon,
     this.enabled = true,
+    this.backgroundColor,
     this.borderColor,
-    this.iconColor, 
-    this.textColor
+    this.iconColor,
+    this.textColor,
   }) : assert(text != null || icon != null, 'ActionButtonViewModel deve ter pelo menos um texto ou um ícone.');
 }

--- a/lib/Samples/actionButtonSampleScreen/action_button_sample_screen.dart
+++ b/lib/Samples/actionButtonSampleScreen/action_button_sample_screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:project_to_do_list/Components/Buttons/action_button.dart';
 import 'package:project_to_do_list/Components/Buttons/action_button_view_model.dart';
-// import 'package:project_to_do_list/Shared/colors.dart'; // remova se não usar diretamente
+import 'package:project_to_do_list/Shared/colors.dart';
+import 'package:project_to_do_list/Shared/styles.dart';
 
 class ActionButtonPage extends StatelessWidget {
   const ActionButtonPage({super.key});
@@ -9,49 +10,36 @@ class ActionButtonPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: brandBackground,
       appBar: AppBar(title: const Text('Estilos de Botões')),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(24),
         child: Center(
           child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 1000),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const _SectionTitle('Estilo primário'),
-                const SizedBox(height: 12),
-                _ButtonShowcase(style: ActionButtonStyle.primary),
-
-                const SizedBox(height: 24),
-                const Divider(),
-
-                const SizedBox(height: 24),
-                const _SectionTitle('Secondary'),
-                const SizedBox(height: 12),
-                _ButtonShowcase(style: ActionButtonStyle.secondary),
-
-                const SizedBox(height: 24),
-                const Divider(),
-
-                const SizedBox(height: 24),
-                const _SectionTitle('Disabled'),
-                const SizedBox(height: 12),
-                _ButtonShowcase(style: ActionButtonStyle.disabled),
-
-                const SizedBox(height: 24),
-                const Divider(),
-
-                const SizedBox(height: 24),
-                const _SectionTitle('Destructive'),
-                const SizedBox(height: 12),
-                _ButtonShowcase(style: ActionButtonStyle.destructive),
-
-                const SizedBox(height: 24),
-                const Divider(),
-
-                const _SectionTitle('Estilo Secudário'),
-
-              ],
+            constraints: const BoxConstraints(maxWidth: 1280),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: brandWhite,
+                borderRadius: BorderRadius.circular(24),
+                boxShadow: const [
+                  BoxShadow(
+                    color: Color(0x0A000000),
+                    blurRadius: 24,
+                    offset: Offset(0, 12),
+                  ),
+                ],
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 40),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    Text('Buttons', style: poppinsRegular24),
+                    SizedBox(height: 32),
+                    _ButtonsTable(),
+                  ],
+                ),
+              ),
             ),
           ),
         ),
@@ -60,121 +48,251 @@ class ActionButtonPage extends StatelessWidget {
   }
 }
 
-/// Título de seção padronizado
-class _SectionTitle extends StatelessWidget {
-  final String text;
-  const _SectionTitle(this.text);
+class _ButtonsTable extends StatelessWidget {
+  static final List<_ButtonVariant> _primaryVariants = [
+    _ButtonVariant(
+      label: 'Primary',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.primary,
+        text: 'Label',
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Secondary',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.secondary,
+        text: 'Label',
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Destructive',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.destructive,
+        text: 'Label',
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Disabled',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.disabled,
+        text: 'Label',
+        enabled: false,
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Icon Only',
+      builder: (size) => ActionButtonViewModel(
+        size: _iconOnlySize(size),
+        style: ActionButtonStyle.primary,
+        icon: Icons.add,
+      ),
+    ),
+  ];
 
-  @override
-  Widget build(BuildContext context) {
-    return Text(
-      text,
-      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w700,
-          ),
-    );
-  }
-}
+  static final List<_ButtonVariant> _secondaryVariants = [
+    _ButtonVariant(
+      label: 'Secondary',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.empty,
+        text: 'Label',
+        textColor: secondaryColor,
+        iconColor: secondaryColor,
+        borderColor: secondaryColor,
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Default',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.empty,
+        text: 'Label',
+        icon: Icons.add,
+        borderColor: lightOutline,
+        textColor: textMain,
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Secondary + Icon',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.empty,
+        text: 'Label',
+        icon: Icons.add,
+        textColor: secondaryColor,
+        iconColor: secondaryColor,
+        borderColor: secondaryColor,
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Disabled',
+      builder: (size) => ActionButtonViewModel(
+        size: size,
+        style: ActionButtonStyle.empty,
+        text: 'Label',
+        enabled: false,
+      ),
+    ),
+    _ButtonVariant(
+      label: 'Icon Only',
+      builder: (size) => ActionButtonViewModel(
+        size: _iconOnlySize(size),
+        style: ActionButtonStyle.empty,
+        icon: Icons.add,
+        borderColor: lightOutline,
+      ),
+    ),
+  ];
 
-/// Mostra os 3 tamanhos (Large/Medium/Small), cada qual com 3 variações:
-/// texto, texto+ícone e ícone-only.
-class _ButtonShowcase extends StatelessWidget {
-  final ActionButtonStyle style;
-  const _ButtonShowcase({required this.style});
+  const _ButtonsTable();
 
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _SizeGroup(
-          label: 'Large',
-          size: ActionButtonSize.large,
-          style: style,
-        ),
-        const SizedBox(height: 16),
-        _SizeGroup(
-          label: 'Medium',
-          size: ActionButtonSize.medium,
-          style: style,
-        ),
-        const SizedBox(height: 16),
-        _SizeGroup(
-          label: 'Small',
-          size: ActionButtonSize.small,
-          style: style,
-        ),
-      ],
-    );
-  }
-}
-
-/// Bloco de tamanho específico com título + variações dos botões.
-/// Usa Wrap para responsividade (quebra de linha automática).
-class _SizeGroup extends StatelessWidget {
-  final String label;
-  final ActionButtonSize size;
-  final ActionButtonStyle style;
-
-  const _SizeGroup({
-    required this.label,
-    required this.size,
-    required this.style,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          label,
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-        ),
-        const SizedBox(height: 8),
-        Wrap(
-          spacing: 12,
-          runSpacing: 12,
-          children: [
-            ActionButton.instantiate(
-              viewModel: ActionButtonViewModel(
-                size: size,
-                style: style,
-                text: label,
-              ),
-            ),
-            ActionButton.instantiate(
-              viewModel: ActionButtonViewModel(
-                size: size,
-                style: style,
-                text: label,
-                icon: Icons.add,
-              ),
-            ),
-            ActionButton.instantiate(
-              viewModel: ActionButtonViewModel(
-                size: _toIconOnly(size),
-                style: style,
-                icon: Icons.add,
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  /// Mapeia o tamanho “texto” para o correspondente “iconOnly”
-  ActionButtonSize _toIconOnly(ActionButtonSize s) {
-    switch (s) {
-      case ActionButtonSize.large || ActionButtonSize.iconOnlyLarge:
+  static ActionButtonSize _iconOnlySize(ActionButtonSize size) {
+    switch (size) {
+      case ActionButtonSize.large:
+      case ActionButtonSize.iconOnlyLarge:
         return ActionButtonSize.iconOnlyLarge;
-      case ActionButtonSize.medium || ActionButtonSize.iconOnlyMedium:
+      case ActionButtonSize.medium:
+      case ActionButtonSize.iconOnlyMedium:
         return ActionButtonSize.iconOnlyMedium;
-      case ActionButtonSize.small || ActionButtonSize.iconOnlySmall:
+      case ActionButtonSize.small:
+      case ActionButtonSize.iconOnlySmall:
         return ActionButtonSize.iconOnlySmall;
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: const [
+            SizedBox(width: 72),
+            _SectionHeading(title: 'Primary'),
+            SizedBox(width: 32),
+            _SectionHeading(title: 'Secondary'),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(width: 72),
+            ..._primaryVariants.map((variant) => _ColumnHeader(label: variant.label)),
+            const SizedBox(width: 32),
+            ..._secondaryVariants.map((variant) => _ColumnHeader(label: variant.label)),
+          ],
+        ),
+        const SizedBox(height: 24),
+        ...ActionButtonSize.values
+            .where((element) => element == ActionButtonSize.large || element == ActionButtonSize.medium || element == ActionButtonSize.small)
+            .map(
+              (size) => Padding(
+                padding: const EdgeInsets.only(bottom: 24),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(
+                      width: 72,
+                      child: Text(
+                        _sizeLabel(size),
+                        style: poppinsRegular14.copyWith(color: textSecondary),
+                      ),
+                    ),
+                    ..._primaryVariants.map(
+                      (variant) => _ButtonCell(
+                        viewModel: variant.builder(size),
+                      ),
+                    ),
+                    const SizedBox(width: 32),
+                    ..._secondaryVariants.map(
+                      (variant) => _ButtonCell(
+                        viewModel: variant.builder(size),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+      ],
+    );
+  }
+
+  String _sizeLabel(ActionButtonSize size) {
+    switch (size) {
+      case ActionButtonSize.large:
+        return 'Large';
+      case ActionButtonSize.medium:
+        return 'Medium';
+      case ActionButtonSize.small:
+        return 'Small';
+      case ActionButtonSize.iconOnlySmall:
+      case ActionButtonSize.iconOnlyMedium:
+      case ActionButtonSize.iconOnlyLarge:
+        return '';
+    }
+  }
+}
+
+class _ButtonVariant {
+  final String label;
+  final ActionButtonViewModel Function(ActionButtonSize size) builder;
+
+  const _ButtonVariant({required this.label, required this.builder});
+}
+
+class _SectionHeading extends StatelessWidget {
+  final String title;
+
+  const _SectionHeading({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 5 * 136,
+      child: Text(
+        title,
+        style: poppinsRegular16.copyWith(fontWeight: FontWeight.w600, color: textPrimary),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}
+
+class _ColumnHeader extends StatelessWidget {
+  final String label;
+
+  const _ColumnHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 136,
+      child: Text(
+        label,
+        style: poppinsRegular12.copyWith(color: textSecondary),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}
+
+class _ButtonCell extends StatelessWidget {
+  final ActionButtonViewModel viewModel;
+
+  const _ButtonCell({required this.viewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 136,
+      child: Center(
+        child: ActionButton.instantiate(viewModel: viewModel),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- extend the action button view model to allow custom background, border, text, and icon colors
- restyle the action button widget to honor the design system sizing, spacing, and color rules, including outline support
- rebuild the sample screen into a two-section grid that mirrors the primary and secondary button variants from the design system

## Testing
- Tests not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5c97f41ec83259e899f597df6cbb4